### PR TITLE
Feat/#6 성공/실패 응답 객체 일반화

### DIFF
--- a/src/main/java/kr/ac/ks/cs_web_back/global/exeption/GlobalExceptionHandler.java
+++ b/src/main/java/kr/ac/ks/cs_web_back/global/exeption/GlobalExceptionHandler.java
@@ -1,0 +1,67 @@
+package kr.ac.ks.cs_web_back.global.exeption;
+
+import kr.ac.ks.cs_web_back.global.exeption.domain.*;
+import kr.ac.ks.cs_web_back.global.exeption.dto.ExceptionCode;
+import kr.ac.ks.cs_web_back.global.exeption.dto.ExceptionResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleException(final Exception e) {
+        System.out.printf("%s : %s\n", e.getClass(),  e.getMessage());
+
+        return ResponseEntity.internalServerError()
+                .body(new ExceptionResponse(5000, "알 수 없는 서버 에러가 발생했습니다."));
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ExceptionResponse> handleException(final BadRequestException e) {
+        System.out.printf("%s : %s\n", e.getClass(),  e.getMessage());
+
+        final ExceptionCode exception = e.getExceptionCode();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ExceptionResponse(exception.getCode(), exception.getMessage()));
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ExceptionResponse> handleException(final UnauthorizedException e) {
+        System.out.printf("%s : %s\n", e.getClass(),  e.getMessage());
+
+        final ExceptionCode exception = e.getExceptionCode();
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ExceptionResponse(exception.getCode(), exception.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ExceptionResponse> handleException(final ForbiddenException e) {
+        System.out.printf("%s : %s\n", e.getClass(),  e.getMessage());
+
+        final ExceptionCode exception = e.getExceptionCode();
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ExceptionResponse(exception.getCode(), exception.getMessage()));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleException(final NotFoundException e) {
+        System.out.printf("%s : %s\n", e.getClass(),  e.getMessage());
+
+        final ExceptionCode exception = e.getExceptionCode();
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ExceptionResponse(exception.getCode(), exception.getMessage()));
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ExceptionResponse> handleException(final ConflictException e) {
+        System.out.printf("%s : %s\n", e.getClass(),  e.getMessage());
+
+        final ExceptionCode exception = e.getExceptionCode();
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ExceptionResponse(exception.getCode(), exception.getMessage()));
+    }
+
+}

--- a/src/main/java/kr/ac/ks/cs_web_back/global/exeption/domain/BadRequestException.java
+++ b/src/main/java/kr/ac/ks/cs_web_back/global/exeption/domain/BadRequestException.java
@@ -1,0 +1,15 @@
+package kr.ac.ks.cs_web_back.global.exeption.domain;
+
+import kr.ac.ks.cs_web_back.global.exeption.dto.ExceptionCode;
+import lombok.Getter;
+
+@Getter
+public class BadRequestException extends RuntimeException {
+
+  ExceptionCode exceptionCode;
+
+    public BadRequestException(ExceptionCode code) {
+        super(code.getMessage());
+        this.exceptionCode = code;
+    }
+}

--- a/src/main/java/kr/ac/ks/cs_web_back/global/exeption/domain/ConflictException.java
+++ b/src/main/java/kr/ac/ks/cs_web_back/global/exeption/domain/ConflictException.java
@@ -1,0 +1,15 @@
+package kr.ac.ks.cs_web_back.global.exeption.domain;
+
+import kr.ac.ks.cs_web_back.global.exeption.dto.ExceptionCode;
+import lombok.Getter;
+
+@Getter
+public class ConflictException extends RuntimeException {
+
+    ExceptionCode exceptionCode;
+
+    public ConflictException(ExceptionCode code) {
+        super(code.getMessage());
+        this.exceptionCode = code;
+    }
+}

--- a/src/main/java/kr/ac/ks/cs_web_back/global/exeption/domain/ForbiddenException.java
+++ b/src/main/java/kr/ac/ks/cs_web_back/global/exeption/domain/ForbiddenException.java
@@ -1,0 +1,15 @@
+package kr.ac.ks.cs_web_back.global.exeption.domain;
+
+import kr.ac.ks.cs_web_back.global.exeption.dto.ExceptionCode;
+import lombok.Getter;
+
+@Getter
+public class ForbiddenException extends RuntimeException {
+
+    ExceptionCode exceptionCode;
+
+    public ForbiddenException(ExceptionCode code) {
+        super(code.getMessage());
+        this.exceptionCode = code;
+    }
+}

--- a/src/main/java/kr/ac/ks/cs_web_back/global/exeption/domain/NotFoundException.java
+++ b/src/main/java/kr/ac/ks/cs_web_back/global/exeption/domain/NotFoundException.java
@@ -1,0 +1,15 @@
+package kr.ac.ks.cs_web_back.global.exeption.domain;
+
+import kr.ac.ks.cs_web_back.global.exeption.dto.ExceptionCode;
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends RuntimeException {
+
+    ExceptionCode exceptionCode;
+
+    public NotFoundException(ExceptionCode code) {
+        super(code.getMessage());
+        this.exceptionCode = code;
+    }
+}

--- a/src/main/java/kr/ac/ks/cs_web_back/global/exeption/domain/UnauthorizedException.java
+++ b/src/main/java/kr/ac/ks/cs_web_back/global/exeption/domain/UnauthorizedException.java
@@ -1,0 +1,15 @@
+package kr.ac.ks.cs_web_back.global.exeption.domain;
+
+import kr.ac.ks.cs_web_back.global.exeption.dto.ExceptionCode;
+import lombok.Getter;
+
+@Getter
+public class UnauthorizedException extends RuntimeException {
+
+    ExceptionCode exceptionCode;
+
+    public UnauthorizedException(ExceptionCode code) {
+        super(code.getMessage());
+        this.exceptionCode = code;
+    }
+}

--- a/src/main/java/kr/ac/ks/cs_web_back/global/exeption/dto/ExceptionCode.java
+++ b/src/main/java/kr/ac/ks/cs_web_back/global/exeption/dto/ExceptionCode.java
@@ -1,0 +1,6 @@
+package kr.ac.ks.cs_web_back.global.exeption.dto;
+
+public interface ExceptionCode {
+    int getCode();
+    String getMessage();
+}

--- a/src/main/java/kr/ac/ks/cs_web_back/global/exeption/dto/ExceptionResponse.java
+++ b/src/main/java/kr/ac/ks/cs_web_back/global/exeption/dto/ExceptionResponse.java
@@ -1,0 +1,7 @@
+package kr.ac.ks.cs_web_back.global.exeption.dto;
+
+public record ExceptionResponse(
+        int code,
+        String message
+) {
+}

--- a/src/main/java/kr/ac/ks/cs_web_back/global/response/CsResponse.java
+++ b/src/main/java/kr/ac/ks/cs_web_back/global/response/CsResponse.java
@@ -1,0 +1,16 @@
+package kr.ac.ks.cs_web_back.global.response;
+
+import jakarta.annotation.Nullable;
+
+public record CsResponse<T>(
+        int code,
+        String message,
+        @Nullable T data
+) {
+    public static <T> CsResponse<T> of(final SuccessCode code) {
+        return new CsResponse<>(code.getCode(), code.getMessage(), null);
+    }
+    public static <T> CsResponse<T> of(final SuccessCode code, T data) {
+        return new CsResponse<>(code.getCode(), code.getMessage(), data);
+    }
+}

--- a/src/main/java/kr/ac/ks/cs_web_back/global/response/SuccessCode.java
+++ b/src/main/java/kr/ac/ks/cs_web_back/global/response/SuccessCode.java
@@ -1,0 +1,6 @@
+package kr.ac.ks.cs_web_back.global.response;
+
+public interface SuccessCode {
+    int getCode();
+    String getMessage();
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #6

<br/>

## 🔎 작업 내용

- 글로벌 성공 응답 레코드 작성
- 글로벌 응답 코드 인터페이스 작성
- 글로벌 예외 응답 핸들러 작성
- 글로벌 예외 응답 코드 인터페이스 작성
- 글로벌 예외 도메인 클래스 작성

### 기존
- 컨트롤러에서 API 응답 시 
  `ResponseEntity.ok().bulid()` 혹은 `ResponseEntity.status(HttpStatus ENUM).body(Response DTO)` 반환
- 예외 발생 시 각 예외 발생 지점에서 `RepsonseEntity.status(HttpStatus).body(new {예외 응답 DTO});` 반환
### 변경
- 컨트롤러에서 API 응답 시 
  `CsResponse.of(ResponseCode ENUM)` 혹은 `CsResponse.of(ResponseCode ENUM, Response DTO)` 반환
    - ResponseCode ENUM 사용으로 코드 가독성 증대
    - 바디가 존재하는 응답 반환 시 체이닝 감소로 인한 클린코드
- 예외 발생 시 각 예외 발생 지점에서 예외 던진 후 예외 핸들러가 실패 응답 생성 및 전송
- 각 도메인별 SuccessCode, ExceptionCode 작성 필요

## ✅ Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [ ] 기존의 코드에 영향이 없는 것을 확인했습니다.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요